### PR TITLE
Clean up zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -6,7 +6,7 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
 fi
 
 # Lines configured by zsh-newuser-install
-HISTFILE=~/.histfile
+HISTFILE=~/.zsh_history
 HISTSIZE=100000
 SAVEHIST=100000
 unsetopt autocd beep
@@ -30,9 +30,6 @@ zstyle ':completion:*' list-colors "${(@s.:.)LS_COLORS}"
 zstyle ':completion:*' menu select
 zstyle ':completion:*' special-dirs true
 
-autoload -Uz compinit
-compinit
-
 #------------------------------------------------------------------------------
 #                               Options
 #------------------------------------------------------------------------------
@@ -40,12 +37,10 @@ compinit
 setopt globdots
 setopt autoparamslash       # Tab completing directory appends a slash
 setopt correct              # Command auto-correction
-setopt correctall           # Argument auto-correction
 setopt interactivecomments  # allow comments, even in interactive shells
 setopt appendhistory        # Append history to the history file (no overwriting)
 # setopt inc_append_history   # Appends every command to the history file once it is executed
 # setopt share_history        # Reloads the history whenever you use it
-setopt HIST_IGNORE_DUPS     # Don't record an entry that was just recorded again.
 setopt HIST_IGNORE_ALL_DUPS # Delete old recorded entry if new entry is a duplicate.
 
 export EDITOR='nvim'
@@ -111,8 +106,7 @@ autoload -Uz _zinit
 zinit light-mode for \
     zdharma-continuum/zinit-annex-readurl \
     zdharma-continuum/zinit-annex-bin-gem-node \
-    zdharma-continuum/zinit-annex-patch-dl \
-    zdharma-continuum/zinit-annex-rust
+    zdharma-continuum/zinit-annex-patch-dl
 # End of Zinit's installer chunk
 
 # Zinit plugins
@@ -129,6 +123,12 @@ zinit as"depth=1" for \
   light-mode romkatv/powerlevel10k
 
 zinit pack"binary+keys" for fzf
+
+# zsh-syntax-highlighting must be loaded last
+zinit light zsh-users/zsh-syntax-highlighting
+
+# Initialise completions after all plugins have registered their compdef calls
+autoload -Uz compinit && compinit -C
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
@@ -174,7 +174,7 @@ export PATH="$HOME/.poetry/bin:$PATH"
 # mise
 eval "$(~/.local/bin/mise activate zsh)"
 
-export PATH="$PATH:/home/fabio/.foundry/bin"
+export PATH="$PATH:$HOME/.foundry/bin"
 
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /usr/bin/terraform terraform


### PR DESCRIPTION
## Changes

| Item | Change |
|---|---|
| `HISTFILE` | Renamed `~/.histfile` → `~/.zsh_history` (standard convention) |
| `compinit` | Removed early call; moved to after all zinit plugins load so every plugin's `compdef` calls are captured before the completion system initialises. Uses `-C` to skip the insecure-directory prompt. |
| `correctall` | Dropped argument auto-correction (too noisy in practice); kept `correct` for command names only |
| `HIST_IGNORE_DUPS` | Removed — `HIST_IGNORE_ALL_DUPS` is a strict superset |
| `zinit-annex-rust` | Removed unused annex |
| `zsh-syntax-highlighting` | Added as the last loaded plugin (required load order) — highlights commands green/red as you type before hitting Enter |
| Foundry `PATH` | Replaced hardcoded `/home/fabio` with `$HOME` |

## Test plan

- [ ] Open a new shell and confirm no errors on startup
- [ ] Confirm completions work (tab-complete a command)
- [ ] Confirm `jk` / `jj` escape still works in insert mode
- [ ] Confirm syntax highlighting colours commands as you type
- [ ] Confirm history is written to `~/.zsh_history`

https://claude.ai/code/session_01URbgH8CrJswR6Uf1Z6TCCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01URbgH8CrJswR6Uf1Z6TCCa)_